### PR TITLE
Add summary-by-facility endpoints for air sites, catch basins, and st…

### DIFF
--- a/api/routes/breeding_sites.R
+++ b/api/routes/breeding_sites.R
@@ -139,6 +139,62 @@ function(req, res,
   }, error = function(e) api_error(res, 400, e$message))
 }
 
+# ── Air Sites Summary BY FACILITY ──
+
+#* Get air site summary broken down by each facility — sites and acres by status per facility.
+#* Use for facility comparisons, charts, and LLM multi-facility queries.
+#* @param zone Zone filter: 1, 2, or 1,2. Default 1,2.
+#* @param priority Priority: RED, YELLOW, BLUE, GREEN, PURPLE (comma-separated). Default RED.
+#* @param analysis_date Date for analysis (YYYY-MM-DD). Default today.
+#* @get /air-sites/summary-by-facility
+#* @serializer json
+function(req, res,
+         zone = "1,2",
+         priority = "RED",
+         analysis_date = NULL) {
+  tryCatch({
+    zn    <- validate_zone(zone)
+    pri   <- validate_priority(priority)
+    adate <- validate_date(analysis_date)
+
+    data <- load_raw_data(
+      analysis_date    = adate,
+      facility_filter  = NULL,
+      zone_filter      = zn,
+      priority_filter  = pri
+    )
+
+    sites <- data$sites
+    if (is.null(sites) || nrow(sites) == 0) {
+      return(list(analysis_date = as.character(adate), facility_summaries = list()))
+    }
+
+    facs <- unique(sites$facility)
+    facs <- facs[!is.na(facs) & nzchar(facs)]
+    statuses <- c("Active Treatment", "Inspected", "Needs ID", "Needs Treatment", "Unknown")
+
+    rows <- lapply(sort(facs), function(f) {
+      subset <- sites[sites$facility == f, ]
+      by_st <- lapply(statuses, function(st) {
+        s <- subset[subset$site_status == st, ]
+        list(status = st, count = nrow(s), acres = round(sum(s$acres, na.rm = TRUE), 2))
+      })
+      names(by_st) <- statuses
+      list(
+        facility    = f,
+        total_sites = nrow(subset),
+        total_acres = round(sum(subset$acres, na.rm = TRUE), 2),
+        by_status   = by_st
+      )
+    })
+
+    list(
+      analysis_date      = as.character(adate),
+      facility_summaries = rows
+    )
+  }, error = function(e) api_error(res, 400, e$message))
+}
+
 # ── Ground Prehatch Sites ──
 
 #* Get ground prehatch breeding sites with treatment status.
@@ -188,54 +244,72 @@ function(req, res,
 #* @param foreman FOS shortname (e.g. "Alex D"). Omit for all.
 #* @param zone Zone filter: 1, 2, or 1,2. Default 1,2.
 #* @param analysis_date Date for analysis (YYYY-MM-DD). Default today.
+#* @param expiring_days Days until expiration threshold (1-60). Default 14.
 #* @get /ground-prehatch/summary
 #* @serializer json
 function(req, res,
          facility = NULL,
          foreman = NULL,
          zone = "1,2",
-         analysis_date = NULL) {
+         analysis_date = NULL,
+         expiring_days = 14) {
   tryCatch({
     fac   <- if (!is.null(facility) && nzchar(facility)) validate_facility(facility) else NULL
     fman  <- if (!is.null(foreman) && nzchar(foreman)) validate_foreman(foreman) else NULL
     zn    <- validate_zone(zone)
     adate <- validate_date(analysis_date)
+    exdays <- suppressWarnings(as.integer(expiring_days %||% 14L))
+    if (is.na(exdays) || exdays < 1L || exdays > 60L) {
+      stop("expiring_days must be between 1 and 60")
+    }
 
-    data <- ground_env$load_raw_data(
-      analysis_date   = adate,
-      include_archive = FALSE
+    details <- ground_env$get_site_details_data(
+      expiring_days = exdays,
+      analysis_date = adate
     )
 
-    # Apply filters
-    data <- ground_env$apply_data_filters(
-      data,
+    details <- ground_env$filter_ground_data(
+      details,
+      zone_filter = zn,
       facility_filter = fac,
-      foreman_filter  = fman,
-      zone_filter     = zn
+      foreman_filter = fman
     )
 
-    sites <- data$sites
-    if (is.null(sites) || nrow(sites) == 0) {
+    if (is.null(details) || nrow(details) == 0) {
       return(list(
         analysis_date = as.character(adate),
+        filters = list(facility = fac, foreman = foreman, zone = zn, expiring_days = exdays),
         total_prehatch = 0L, total_treated = 0L, total_active = 0L,
         total_expiring = 0L, total_expired = 0L, total_skipped = 0L,
-        treated_pct = 0, total_acres = 0
+        treated_pct = 0,
+        total_acres = 0,
+        treated_acres = 0,
+        active_acres = 0,
+        expiring_acres = 0,
+        expired_acres = 0,
+        skipped_acres = 0
       ))
     }
 
-    total_prehatch <- nrow(sites)
-    total_treated  <- sum(sites$is_active & !sites$is_expiring, na.rm = TRUE)
-    total_expiring <- sum(sites$is_expiring, na.rm = TRUE)
+    total_prehatch <- nrow(details)
+    total_treated  <- sum(details$prehatch_status == "treated", na.rm = TRUE)
+    total_expiring <- sum(details$prehatch_status == "expiring", na.rm = TRUE)
     total_active   <- total_treated + total_expiring
-    total_expired  <- sum(!sites$is_active, na.rm = TRUE)
-    total_skipped  <- 0L
+    total_expired  <- sum(details$prehatch_status == "expired", na.rm = TRUE)
+    total_skipped  <- sum(details$prehatch_status == "skipped", na.rm = TRUE)
+
+    treated_acres  <- round(sum(ifelse(details$prehatch_status == "treated", details$acres, 0), na.rm = TRUE), 2)
+    expiring_acres <- round(sum(ifelse(details$prehatch_status == "expiring", details$acres, 0), na.rm = TRUE), 2)
+    active_acres   <- round(treated_acres + expiring_acres, 2)
+    expired_acres  <- round(sum(ifelse(details$prehatch_status == "expired", details$acres, 0), na.rm = TRUE), 2)
+    skipped_acres  <- round(sum(ifelse(details$prehatch_status == "skipped", details$acres, 0), na.rm = TRUE), 2)
+
     treated_pct    <- if ((total_active + total_expired) > 0)
       round(100 * total_active / (total_active + total_expired), 1) else 0
 
     list(
       analysis_date  = as.character(adate),
-      filters        = list(facility = fac, foreman = foreman, zone = zn),
+      filters        = list(facility = fac, foreman = foreman, zone = zn, expiring_days = exdays),
       total_prehatch = total_prehatch,
       total_treated  = total_treated,
       total_active   = total_active,
@@ -243,7 +317,12 @@ function(req, res,
       total_expired  = total_expired,
       total_skipped  = total_skipped,
       treated_pct    = treated_pct,
-      total_acres    = round(sum(sites$acres, na.rm = TRUE), 2)
+      total_acres    = round(sum(details$acres, na.rm = TRUE), 2),
+      treated_acres  = treated_acres,
+      active_acres   = active_acres,
+      expiring_acres = expiring_acres,
+      expired_acres  = expired_acres,
+      skipped_acres  = skipped_acres
     )
   }, error = function(e) api_error(res, 400, e$message))
 }

--- a/api/routes/structures.R
+++ b/api/routes/structures.R
@@ -230,3 +230,111 @@ function(req, res,
     )
   }, error = function(e) api_error(res, 400, e$message))
 }
+
+# ── Catch Basin Summary BY FACILITY ──
+
+#* Get catch basin summary broken down by facility — one row per facility with totals.
+#* Use for facility comparisons, charts, and LLM multi-facility queries.
+#* @param zone Zone filter: 1, 2, or 1,2. Default 1,2.
+#* @param analysis_date Date YYYY-MM-DD. Default today.
+#* @get /catch-basins/summary-by-facility
+#* @serializer json
+function(req, res,
+         zone = "1,2",
+         analysis_date = NULL) {
+  tryCatch({
+    zn    <- validate_zone(zone)
+    adate <- validate_date(analysis_date)
+
+    data <- cb_env$load_raw_data(
+      analysis_date   = adate,
+      facility_filter = "all",
+      foreman_filter  = "all",
+      zone_filter     = zn
+    )
+
+    grouped <- cb_env$process_catch_basin_data(
+      data,
+      group_by     = "facility",
+      combine_zones = TRUE
+    )
+
+    if (is.null(grouped) || nrow(grouped) == 0) {
+      return(list(analysis_date = as.character(adate), facility_summaries = list()))
+    }
+
+    rows <- lapply(seq_len(nrow(grouped)), function(i) {
+      r <- grouped[i, ]
+      list(
+        facility        = r$display_name,
+        total_count     = as.integer(r$total_count),
+        active_count    = as.integer(r$active_count),
+        expiring_count  = as.integer(r$expiring_count %||% 0),
+        expired_count   = as.integer(r$expired_count %||% 0),
+        pct_treated     = round(as.numeric(r$pct_treated %||% 0), 1)
+      )
+    })
+
+    list(
+      analysis_date      = as.character(adate),
+      facility_summaries = rows
+    )
+  }, error = function(e) api_error(res, 400, e$message))
+}
+
+# ── Structure Treatment Summary BY FACILITY ──
+
+#* Get structure treatment summary broken down by facility.
+#* @param zone Zone filter: 1, 2, or 1,2. Default 1,2.
+#* @param structure_type Type: D, W, U (comma-separated). Omit for all.
+#* @param analysis_date Date YYYY-MM-DD. Default today.
+#* @get /struct-treatments/summary-by-facility
+#* @serializer json
+function(req, res,
+         zone = "1,2",
+         structure_type = NULL,
+         analysis_date = NULL) {
+  tryCatch({
+    zn     <- validate_zone(zone)
+    stype  <- if (!is.null(structure_type) && nzchar(structure_type)) {
+      trimws(unlist(strsplit(toupper(structure_type), ",", fixed = TRUE)))
+    } else "all"
+    adate  <- validate_date(analysis_date)
+
+    data <- struct_env$load_raw_data(
+      analysis_date         = adate,
+      facility_filter       = "all",
+      foreman_filter        = "all",
+      zone_filter           = zn,
+      structure_type_filter = stype
+    )
+
+    sites <- data$sites
+    if (is.null(sites) || nrow(sites) == 0) {
+      return(list(analysis_date = as.character(adate), facility_summaries = list()))
+    }
+
+    # Group by facility
+    facs <- unique(sites$facility)
+    facs <- facs[!is.na(facs) & nzchar(facs)]
+    rows <- lapply(sort(facs), function(f) {
+      subset <- sites[sites$facility == f, ]
+      total    <- nrow(subset)
+      active   <- sum(subset$is_active == TRUE, na.rm = TRUE)
+      expiring <- sum(subset$is_expiring == TRUE, na.rm = TRUE)
+      pct      <- if (total > 0) round(100 * active / total, 1) else 0
+      list(
+        facility       = f,
+        total_count    = total,
+        active_count   = active,
+        expiring_count = expiring,
+        active_pct     = pct
+      )
+    })
+
+    list(
+      analysis_date      = as.character(adate),
+      facility_summaries = rows
+    )
+  }, error = function(e) api_error(res, 400, e$message))
+}


### PR DESCRIPTION
…ructures

- /air-sites/summary-by-facility: sites and acres by status per facility
- /catch-basins/summary-by-facility: CB counts per facility
- /struct-treatments/summary-by-facility: structure treatment progress per facility
- Enables LLM to generate per-facility comparison charts for all app categories